### PR TITLE
on windows, paths are case-insensitive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Treat all files in the Go repo as binary, with no git magic updating
+# line endings. This produces predictable results in different environments.
+#
+# See golang.org/issue/9281.
+
+* -text

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+# backups
+*~

--- a/abide.go
+++ b/abide.go
@@ -220,7 +220,7 @@ func reloadSnapshots() error {
 	paths := []string{}
 	for _, file := range files {
 		path := filepath.Join(dir, file.Name())
-		if filepath.Ext(path) == snapshotExt {
+		if isSnapshot(path) {
 			paths = append(paths, path)
 		}
 	}

--- a/abide_nix.go
+++ b/abide_nix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+// +build !windows
+
+package abide
+
+import "path/filepath"
+
+func isSnapshot(path string) bool {
+	return filepath.Ext(path) == snapshotExt
+}

--- a/abide_windows.go
+++ b/abide_windows.go
@@ -1,0 +1,10 @@
+package abide
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+func isSnapshot(path string) bool {
+	return strings.EqualFold(filepath.Ext(path), snapshotExt)
+}


### PR DESCRIPTION
Also, tell git to always check out things in 'binary' mode on windows. Otherwise in some situations the snapshot files will have `\r\n` newlines which confuses abide.